### PR TITLE
Minor changes in the token manager for extensibility

### DIFF
--- a/repoze/who/plugins/vepauth/tokenmanager.py
+++ b/repoze/who/plugins/vepauth/tokenmanager.py
@@ -110,8 +110,7 @@ class SignedTokenManager(object):
         including an expiry time and salt.  It has a HMAC signature appended
         and is b64-encoded for transmission.
         """
-        if ('application' in request.matchdict and self.applications
-            and request.matchdict['application'] not in self.applications):
+        if self._is_request_valid(request, data):
             raise HTTPNotFound()
 
         data = data.copy()
@@ -157,6 +156,18 @@ class SignedTokenManager(object):
                 raise ValueError("token contains no userid")
         # Re-generate the secret key and return.
         return data, self._get_secret(token, data)
+
+    def _is_request_valid(self, request, data):
+        """Checks that the request is valid.
+
+        If the matchdict contains "application", checks that application is one
+        of the defined ones in self.applications.
+
+        This method is to be overwritted by potential cihlds of this class, for
+        e.g looking the list of possible application choices in a database.
+        """
+        return ('application' in request.matchdict and self.applications
+                 and request.matchdict['application'] not in self.applications)
 
     def _get_secret(self, token, data):
         """Get the secret key associated with the given token.


### PR DESCRIPTION
Request verification is now done in a separate method, so it is simpler to
extend the `SignedTokenManager` class to have a different behavior (if we want
to reject other requests than the ones based only on the "{application}"
pattern).
